### PR TITLE
remove jsx-quotes rule

### DIFF
--- a/fix.js
+++ b/fix.js
@@ -6,7 +6,6 @@ module.exports = {
   plugins: ['babel', 'mocha', 'flowtype', 'react'],
   rules: {
     'arrow-parens': [2, 'always'],
-    'jsx-quotes': [2, 'prefer-single'],
     'react/jsx-closing-bracket-location': [2, {selfClosing: 'after-props', nonEmpty: 'after-props'}],
     'react/jsx-space-before-closing': [2, 'always'],
   },

--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ module.exports = {
     'generator-star-spacing': 0, // has bug, disable for now
     'guard-for-in': 0,
     'id-length': 0,
-    'jsx-quotes': [2, 'prefer-single'],
     'max-len': 0,
     'new-cap': 0,
     'no-await-in-loop': 0,


### PR DESCRIPTION
prettier does not support jsx-quotes and always will use double-quotes even
when the option --single-quote is enabled. So prettier will change all quotes
in jsx to double quotes and eslint will change it back to single quotes.
https://github.com/prettier/prettier/issues/3437